### PR TITLE
Feature: ros2 and relative package path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
I suggest a fallback strategy for resolving package paths: If rospkg fails try ament to get the package to import the mesh and if that fails as well try if a local folder with the name of the package exists