### PR TITLE
Force object to become single_user before applying modifiers

### DIFF
--- a/urdf_importer_addon/urdf_importer/robot_builder.py
+++ b/urdf_importer_addon/urdf_importer/robot_builder.py
@@ -397,6 +397,11 @@ class RobotBuilder:
             object = bpy.context.object
             if self.apply_weld:
                 object.modifiers.new("Weld", "WELD")
+                # Modifiers cannot be applied to
+                # multi-user data, so we make it single.
+                bpy.ops.object.make_single_user(
+                    object=True, obdata=True, material=False,
+                    animation=False, obdata_animation=False)
                 bpy.ops.object.modifier_apply(modifier="Weld")
             if material is not None:
                 object.data.materials.append(material)


### PR DESCRIPTION
Blender 4.1 gives the error message 'Modifiers cannot be applied to multi-user data' on the turtlebot3-description packages for ROS2, so we force single_user before applying the modifier