### PR TITLE
Forcing inclussion of ROS2 Packages

### DIFF
--- a/urdf_importer_addon/urdf_importer/robot_builder.py
+++ b/urdf_importer_addon/urdf_importer/robot_builder.py
@@ -3,9 +3,11 @@
 import sys
 
 # Avoid ROS packages interfering, e.g. urdf_parser_py
-ros_path = [p for p in sys.path if p.startswith("/opt/ros")]
-sys.path = [p for p in sys.path if not p.startswith("/opt/ros")]
-sys.path = sys.path + ros_path
+ros_path = glob.glob("/opt/ros/*/lib/*/site-packages")
+
+if ros_path not in sys.path:
+    sys.path.extend(ros_path)
+
 
 import os
 from shutil import copy


### PR DESCRIPTION
The previous way of adding ROS2 packages wasn't working in my system so I forced the inclusion of the libraries